### PR TITLE
fix certain logos not showing after export

### DIFF
--- a/godot-awesome-splash/addons/awesome_splash/core/AweSplashScreen.gd
+++ b/godot-awesome-splash/addons/awesome_splash/core/AweSplashScreen.gd
@@ -40,12 +40,13 @@ func update_aspect_node_frame(parent_size: Vector2):
 
 func load_texture(path: String) -> ImageTexture:
 	var image = Image.new()
-	var err = image.load(path)
-	
+	var stream_texture = load(path)
 	var texture = ImageTexture.new()
-	if err != OK:
+	if stream_texture == null:
 		print("%s is load fail" % path)
 		return texture
+	image = stream_texture.get_data()
+	image.lock()
 	
 	texture.create_from_image(image, 0)
 	return texture


### PR DESCRIPTION
I noticed there was a warning in the editor when I was using the twist splash screen:
![godot-awesome-splash_warning](https://user-images.githubusercontent.com/50096660/167128790-f3e570b3-c20f-471f-a253-530d1d8ea884.png)
What it was suggesting was correct. It did not work on export (on v3.4.4.stable.official [419e713a2]).

I tested on Linux:
![godot-awesome-splash_bug_0](https://user-images.githubusercontent.com/50096660/167128920-c4e17026-41eb-4a40-9208-e8ecfc07fe52.GIF)
I tested on Android:
![godot-awesome-splash_bug_1](https://user-images.githubusercontent.com/50096660/167129007-e5a52fa8-bf40-45b0-8719-f657a8000bc5.GIF)
Neither of them showed the Godot icon because the image was not being loaded after the project was exported.

When looking for solutions, I ran across this on the internet: https://godotengine.org/qa/50031/image-fails-export-with-warning-loading-resource-image-export

This seemed to be the same problem I was experiencing. So I rewrote `AweSplashScreen.load_texture(String)` a bit. Instead of using `image.load(path)`, I loaded `path` as a resource in a variable called `stream_texture` using `load(path)`. Then, I set `image` to the image data from `stream_texture.get_data()`. This pretty much achieves the same thing, but without the warning. It also appears to work on export.

I tested on Linux:
![godot-awesome-splash_fixed_0](https://user-images.githubusercontent.com/50096660/167130984-ecae6916-1b2b-42be-8b05-ee7a804b0eb3.GIF)
I tested on Android:
![godot-awesome-splash_fixed_1](https://user-images.githubusercontent.com/50096660/167131070-f489a0e9-3632-434e-ae97-441798637f39.GIF)
Both show the Godot icon now.