### PR TITLE
Fix error on exporting with logo being unable to load properly

### DIFF
--- a/godot-awesome-splash/addons/awesome_splash/core/AweSplashScreen.gd
+++ b/godot-awesome-splash/addons/awesome_splash/core/AweSplashScreen.gd
@@ -39,16 +39,11 @@ func update_aspect_node_frame(parent_size: Vector2):
 	aspect_node.parrent_size = parent_size
 
 
-func load_texture(path: String) -> ImageTexture:
-#	var image = Image.new()
-#	var stream_texture = load(path)
-	var image = Image.load_from_file(path)
-	var texture = ImageTexture.create_from_image(image)
+func load_texture(path: String):
+	var texture = load(path)
 	if texture == null:
-		print("%s is load fail" % path)
-		return ImageTexture.new()
-#	image = stream_texture.get_data()
-#	image.lock()
+		push_error("Wasn't able to load the texture located: " + path)
+		return 1
 
 	return texture
 


### PR DESCRIPTION
According to the [Godot docs](https://docs.godotengine.org/en/stable/classes/class_imagetexture.html#description) loading a texture the old way could (and does) cause problems on export by the image not being loaded.

I just changed to calling the dynamic load() function which fixes the issues on exporting and is the best way according to the docs